### PR TITLE
Update salmon index main.nf

### DIFF
--- a/modules/salmon/index/main.nf
+++ b/modules/salmon/index/main.nf
@@ -20,8 +20,6 @@ process SALMON_INDEX {
     /*********** INPUT ***********/
     input:
         path transcriptome
-        path genome
-        path decoys
     
     /*********** OUTPUT ***********/
     //Define output channels and assign identifiers
@@ -34,37 +32,22 @@ process SALMON_INDEX {
         def args = task.ext.args ?: ''
         def threads = (args.indexOf('-p ') > 1) ? '' : "-p ${task.cpus}"
         def tfilename = "${transcriptome.name}"
-        def gfilename = "${genome.name}"
-        def gentrome;
         // Log
-        // log.info "Genome ${gfilename}"
         // log.info "Transcriptome ${tfilename}"
         
         // Check extension
-        if( (tfilename.endsWith('.fa.gz') || tfilename.endsWith('.fasta.gz')) &&  
-            (gfilename.endsWith('.fa.gz') || gfilename.endsWith('.fasta.gz'))){
-            gentrome = 'gentrome.fa.gz'
-            log.info "Genome and transcriptome are both compressed FASTA files"
-        } else if( (tfilename.endsWith('.fa') || tfilename.endsWith('.fasta')) &&
-            (gfilename.endsWith('.fa') || gfilename.endsWith('.fasta'))){
-            gentrome = 'gentrome.fa'
-            log.info "Genome and transcriptome are both uncompressed FASTA files"
-        } else {
-            error "ERROR: genome and transcriptome extensions do not match"
+        if (tfilename.endsWith('.fa.gz') || tfilename.endsWith('.fasta.gz')){
+            log.info "Transcriptome is a compressed FASTA file"
+        } else (tfilename.endsWith('.fa') || tfilename.endsWith('.fasta')){
+            log.info "Transcriptome is an uncompressed FASTA file"
         }
-
-        // Check decoys
-        def idecoys = decoys ? "--d ${decoys}" : ''
 
         """
         #!/usr/bin/env bash
 
-        cat ${transcriptome} ${genome} > ${gentrome}
-
         salmon index \
             ${threads} \
-            -t ${gentrome} \
-            ${idecoys} \
+            -t ${transcriptome} \
             ${args} \
             -i salmon
 


### PR DESCRIPTION
Removed the decoys options in this code. This code generates a decoy UNAWARE index if user supplied decoys are not found and the --decoys option is not selected. As far as I know, this generally isn't recommended so maybe we could add a warning message when this code runs