### PR TITLE
Update check_and_prepare_input.nf

### DIFF
--- a/subworkflows/check_and_prepare_input.nf
+++ b/subworkflows/check_and_prepare_input.nf
@@ -320,43 +320,43 @@ workflow CHECK_AND_PREPARE_INPUT {
 
                     // Check decoys
                     if(params.decoys){
-						if((params.decoys instanceof String) && file(params.decoys).exists()){
-							log.info "Decoys file found"
-							ch_decoys = Channel.fromPath(params.decoys, type: 'file')
-						} else {
-							log.info "Decoys file not found. A decoys file will be generated."
-							if(params.decoys instanceof String){
-								fn_decoys = file(params.decoys).name
-							} else {
-								fn_decoys = "decoys.txt"
-							}
+                        if((params.decoys instanceof String) && file(params.decoys).exists()){
+                            log.info "Decoys file found"
+                            ch_decoys = Channel.fromPath(params.decoys, type: 'file')
+                        } else {
+                            log.info "Decoys file not found. A decoys file will be generated."
+                            if(params.decoys instanceof String){
+                                fn_decoys = file(params.decoys).name
+                            } else {
+                                fn_decoys = "decoys.txt"
+                            }
 
-							// Create decoys file.
-							CREATE_DECOYS_FILE(
-								ch_genome,
-								fn_decoys
-								// file(params.decoys).parent
-							)
-							ch_decoys = CREATE_DECOYS_FILE.out.decoys
+                            // Create decoys file.
+                            CREATE_DECOYS_FILE(
+                                ch_genome,
+                                fn_decoys
+                                // file(params.decoys).parent
+                            )
+                            ch_decoys = CREATE_DECOYS_FILE.out.decoys
 
-							// Update versions
-							ch_versions = ch_versions.mix(CREATE_DECOYS_FILE.out.versions) 
-						}
-					} else {
-						log.info "Decoys option is not selected. No decoys will be used in generating the index. This is not recommended."
-						ch_decoys = Channel.empty()
-					}
+                            // Update versions
+                            ch_versions = ch_versions.mix(CREATE_DECOYS_FILE.out.versions)
+                        }
+                    } else {
+                        log.info "Decoys option is not selected. No decoys will be used in generating the index. This is not recommended."
+                        ch_decoys = Channel.empty()
+                    }
 
                     // Create index
-					SALMON_INDEX(
-						ch_transcriptome,
-						ch_genome,
-						ch_decoys.collect().ifEmpty([])
-					)
+                    SALMON_INDEX(
+                        ch_transcriptome,
+                        ch_genome,
+                        ch_decoys.collect().ifEmpty([])
+                    )
 
                     // Output channel
                     ch_salmon_index = SALMON_INDEX.out.index
-                    
+
                     // Update versions
                     ch_versions = ch_versions.mix(SALMON_INDEX.out.versions)     
                 }

--- a/subworkflows/check_and_prepare_input.nf
+++ b/subworkflows/check_and_prepare_input.nf
@@ -320,37 +320,39 @@ workflow CHECK_AND_PREPARE_INPUT {
 
                     // Check decoys
                     if(params.decoys){
-                        if((params.decoys instanceof String) && file(params.decoys).exists()){
-                            log.info "Decoys file found"
-                            ch_decoys = Channel.fromPath(params.decoys, type: 'file')
-                        } else {
-				            if(params.decoys instanceof String){
-				                fn_decoys = file(params.decoys).name
-				            } else {
-					            fn_decoys = "decoys.txt"
-				            }
-                            log.info "Decoys file not found. A decoys file will be generated."
-                            // Create decoys file.
-			                CREATE_DECOYS_FILE(
-                                ch_genome,
-                                fn_decoys
-                                // file(params.decoys).parent
-                            )
-                            ch_decoys = CREATE_DECOYS_FILE.out.decoys
-                            // Update versions
-                            ch_versions = ch_versions.mix(CREATE_DECOYS_FILE.out.versions) 
-                        }
-                    } else {
-                        log.info "Decoys option is not selected. No decoys will be used in generating the index. This is not recommended."
-                        ch_decoys = Channel.empty()
-			        }
+						if((params.decoys instanceof String) && file(params.decoys).exists()){
+							log.info "Decoys file found"
+							ch_decoys = Channel.fromPath(params.decoys, type: 'file')
+						} else {
+							log.info "Decoys file not found. A decoys file will be generated."
+							if(params.decoys instanceof String){
+								fn_decoys = file(params.decoys).name
+							} else {
+								fn_decoys = "decoys.txt"
+							}
+
+							// Create decoys file.
+							CREATE_DECOYS_FILE(
+								ch_genome,
+								fn_decoys
+								// file(params.decoys).parent
+							)
+							ch_decoys = CREATE_DECOYS_FILE.out.decoys
+
+							// Update versions
+							ch_versions = ch_versions.mix(CREATE_DECOYS_FILE.out.versions) 
+						}
+					} else {
+						log.info "Decoys option is not selected. No decoys will be used in generating the index. This is not recommended."
+						ch_decoys = Channel.empty()
+					}
 
                     // Create index
-                    SALMON_INDEX(
-                        ch_transcriptome,
-                        ch_genome,
-                        ch_decoys.collect().ifEmpty([])
-                    )
+					SALMON_INDEX(
+						ch_transcriptome,
+						ch_genome,
+						ch_decoys.collect().ifEmpty([])
+					)
 
                     // Output channel
                     ch_salmon_index = SALMON_INDEX.out.index


### PR DESCRIPTION
Fix bug where an empty decoys channel prevents the program from building a salmon index.

1. If the decoys option is not selected, an index will be built without it
2. A decoys file is created with the filename decoys.txt if the --decoys option is used with no argument
3. A decoys file is created with a user supplied filename if the --decoys option is used with an argument but no associated file
4. A user supplied decoys file can be input and used in building the salmon index if --decoys is used and the argument refers to an existing file