### PR TITLE
Update main.nf

### DIFF
--- a/modules/fastqc/main.nf
+++ b/modules/fastqc/main.nf
@@ -33,7 +33,7 @@ process FASTQC {
         // echo "\nFASTQC:   ${meta}\n"
         // echo "\nFASTQC:   ${reads}\n"
         def files1 = reads1.join(' ')
-        def files2 = reads1.join(' ')
+        def files2 = reads2.join(' ')
 
         if(meta.single_end){
             """

--- a/modules/fastqc/main.nf
+++ b/modules/fastqc/main.nf
@@ -13,11 +13,12 @@ process FASTQC {
         'https://depot.galaxyproject.org/singularity/fastqc:0.11.9--hdfd78af_1' : 
         'quay.io/biocontainers/fastqc:0.11.9--hdfd78af_1'}"
     //Specifies where to publish output
-    publishDir path: "${params.outdir}/fastqc" , mode: "${params.publishdir_mode}", overwrite: true, followLinks: true
+    publishDir path: "${params.outdir}/${fastqc_dir}" , mode: "${params.publishdir_mode}", overwrite: true, followLinks: true
     
     /*********** INPUT ***********/
     input:
         tuple val(meta), path(reads1), path(reads2)
+        val fastqc_dir
     
     /*********** OUTPUT ***********/
     //Define output channels and assign identifiers


### PR DESCRIPTION
Fixes the bug where fastqc is run on read 1 of paired end reads in duplicate due to a typo
This can be accepted without any of the cutadapt related changes being made