### PR TITLE
Update main.nf

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -256,7 +256,6 @@ workflow {
     //---------------------------------------------
     // Adapter trimming
     //---------------------------------------------    
-
     if(modules_to_run.contains('cutadapt')){
         ch_cutadapt_options = Channel.fromPath(params.cutadapt_options, type: 'file')
 	CUTADAPT(
@@ -266,8 +265,14 @@ workflow {
         // Update 
 	ch_reads = CUTADAPT.out.reads
         ch_versions = ch_versions.mix(CUTADAPT.out.versions.first())
+    }
 
-        if(modules_to_run.contains('fastqc_cutadapt')){
+    if(modules_to_run.contains('fastqc_cutadapt')){
+        if(modules_to_run.contains('fastqc') && !modules_to_run.contains('cutadapt')){
+            exit 1, 'ERROR: The fastqc and fastqc_cutadapt modules may not be specified together unless the cutadapt module is also present'
+        }
+
+        if(modules_to_run.contains('cutadapt') | params.input.endsWith('cutadapt/')){
             ch_fastqc_dir = 'fastqc_cutadapt'
             FASTQC_CUTADAPT(
                 ch_reads,
@@ -275,24 +280,8 @@ workflow {
             )
             // Update versions
             ch_versions = ch_versions.mix(FASTQC_CUTADAPT.out.versions.first())
-        }
-    } else { // so if modules_to_run does NOT contain cutadapt
-        if(modules_to_run.contains('fastqc_cutadapt')) {
-            if(modules_to_run.contains('fastqc')){
-                exit 1, 'ERROR: The fastqc and fastqc_cutadapt modules may not be specified together unless the cutadapt module is also present'
-            } else {
-                if(params.input.endsWith('cutadapt/')){
-                    ch_fastqc_dir = 'fastqc_cutadapt'
-                    FASTQC_CUTADAPT(
-                        ch_reads,
-                        ch_fastqc_dir
-                    )
-                    // Update versions
-                    ch_versions = ch_versions.mix(FASTQC_CUTADAPT.out.versions.first())
-                } else {
-                    exit 1, 'ERROR: The fastqc_cutadapt module is specified without the cutadapt module, and the input files are not stored in a cutadapt/ directory. Update the input directory and the suffix parameters to feed the trimmed files into fastqc_cutadapt directly.'
-                }
-            }
+        } else {
+            exit 1, 'ERROR: The fastqc_cutadapt module is specified without the cutadapt module, and the input files are not stored in a cutadapt/ directory. Update the input directory and the suffix parameters to feed the trimmed files into fastqc_cutadapt directly.'
         }
     }
 

--- a/main.nf
+++ b/main.nf
@@ -258,8 +258,10 @@ workflow {
     //---------------------------------------------    
 
     if(modules_to_run.contains('cutadapt')){
+        ch_cutadapt_options = Channel.fromPath(params.cutadapt_options, type: 'file')
 	CUTADAPT(
-            ch_reads
+            ch_reads,
+            ch_cutadapt_options.collect()
         )
         // Update 
 	ch_reads = CUTADAPT.out.reads

--- a/main.nf
+++ b/main.nf
@@ -38,8 +38,8 @@ def helpMessage() {
             --transcriptome     FILEPATH            FASTA file containing the transcriptome (can be a gzip file)
             --salmon_index      DIRPATH             Folder containing the index on the transcriptome. If empty
                                                     a new index will be automatically generated
-            --modules           STRING              The pipeline modules to run (default: 'fastqc,quant,multiqc').
-                                                    Available modules are: fastqc, quant, multiqc
+            --modules           STRING              The pipeline modules to run (default: 'fastqc,cutadapt,fastqc_cutadapt,quant,multiqc').
+                                                    Available modules are: fastqc, cutadapt, fastqc_cutadapt, quant, multiqc
 
         Optional arguments:
             --filext            STRING              Extension of input files (default: fq.gz)
@@ -50,6 +50,8 @@ def helpMessage() {
                                                     lanes)
             --prefix            STRING              Regular expression used to identify groups of multiple
                                                     files to concatenate (e.g., --prefix LANE(\\d+)_)
+            --cutadapt_options FILEPATH		           File containing a single line of options to be fed into cutadapt. 
+						                                              Input/output files do not need to be specified.
             --species           STRING              Species of the samples (e.g., --species hsapiens). 
                                                     This parameter is used to create the output sub-folders 
                                                     and to download genome/transcriptome data (if required)
@@ -107,6 +109,9 @@ def initialLogMessage() {
     if (params.suffix2       ) log.info "suffix2        = ${params.suffix2}"
     if (params.filext        ) log.info "filext         = ${params.filext}"
     if (params.outdir        ) log.info "outdir         = ${params.outdir}"
+
+    log.info "\nCUTADAPT ------------------------------"
+    if (params.cutadapt_options) log.info "cutadapt_options = ${params.cutadapt_options}"
 
     log.info "\nREFERENCES ------------------------------"   
     if (params.species       ) log.info "species        = ${params.species}"
@@ -172,6 +177,8 @@ def modules_to_run = params.modules ? "${params.modules}".split(',') : []
 **************************************************/
 include { FASTQC            } from './modules/fastqc'
 include { MULTIQC           } from './modules/multiqc'
+include { CUTADAPT	         }	from './modules/cutadapt'
+include { FASTQC_CUTADAPT   } from './modules/fastqc_cutadapt'
 include { SALMON_QUANT      } from './modules/salmon/quant'
 include { TXIMPORT_SALMON   } from './modules/tximport/salmon'
 include { SOFTWARE_VERSIONS } from './modules/custom/swversions'
@@ -225,12 +232,12 @@ workflow {
     //---------------------------------------------
     // FastQC
     //---------------------------------------------
-    ch_fastqc = Channel.empty()
+
     if(modules_to_run.contains('fastqc')){
         FASTQC(
             ch_reads
         )
-        // ch_fastqc = FASTQC.out.zip.view(it -> "[FASTQC] $it")
+
         // Update versions
         ch_versions = ch_versions.mix(FASTQC.out.versions.first())
     }
@@ -242,6 +249,43 @@ workflow {
         // Update
         ch_reads = CONCATENATE_READS.out.reads
         ch_versions = ch_versions.mix(CONCATENATE_READS.out.versions)
+    }
+
+    //---------------------------------------------
+    // Adapter trimming
+    //---------------------------------------------    
+    if(modules_to_run.contains('fastqc_cutadapt') && !modules_to_run.contains('cutadapt')) {
+        if(modules_to_run.contains('fastqc')){
+            exit 1, 'ERROR: The fastqc and fastqc_cutadapt modules may not be specified together unless the cutadapt module is also present' 
+        }
+        if(!modules_to_run.contains('fastqc') && params.input.endsWith('cutadapt/')){
+            FASTQC_CUTADAPT(
+                ch_reads
+            )
+            // Update versions
+            ch_versions = ch_versions.mix(FASTQC_CUTADAPT.out.versions.first())
+        } else {
+            exit 1, 'ERROR: The fastqc_cutadapt module is specified without the cutadapt module, and the input files are not stored in a cutadapt/ directory. Update the input directory and the suffix parameters to feed the trimmed files into fastqc_cutadapt directly.'
+        }
+    }
+
+    if(modules_to_run.contains('cutadapt')){
+        ch_cutadapt_options = Channel.fromPath(params.cutadapt_options, type: 'file')
+        CUTADAPT(
+            ch_reads,
+            ch_cutadapt_options.collect()
+        )
+        // Update 
+        ch_reads = CUTADAPT.out.reads
+        ch_versions = ch_versions.mix(CUTADAPT.out.versions.first())
+
+        if(modules_to_run.contains('fastqc_cutadapt')){
+            FASTQC_CUTADAPT(
+                ch_reads
+            )
+            // Update versions
+            ch_versions = ch_versions.mix(FASTQC_CUTADAPT.out.versions.first())
+        }
     }
 
     //---------------------------------------------
@@ -261,7 +305,6 @@ workflow {
             Channel.value(params.salmon_libtype)
         )
         // Update channels
-        ch_salmon_multiqc = SALMON_QUANT.out.quant
         ch_versions = ch_versions.mix(SALMON_QUANT.out.versions.first())
 
         // Summarisation at gene-level
@@ -273,9 +316,6 @@ workflow {
             // Update channels
             ch_versions = ch_versions.mix(TXIMPORT_SALMON.out.versions)
         }
-
-    } else {
-        ch_salmon_multiqc = Channel.empty()
     }
 
     //---------------------------------------------
@@ -300,10 +340,10 @@ workflow {
         //so that they are correctly staged.
         MULTIQC(
             ch_multiqc_config,
-            SOFTWARE_VERSIONS.out.multiqc_yml.collect(),
-            ch_fastqc.collect{it[1]}.ifEmpty([]),
-            ch_salmon_multiqc.collect{it[1]}.ifEmpty([])
+            SOFTWARE_VERSIONS.out.multiqc_yml.collect()
         )
+        // Update channels
+        ch_versions = ch_versions.mix(MULTIQC.out.versions)
     }
 }
 


### PR DESCRIPTION
Lots of changes:
1. Update module names in info
2. Added the instructions for cutadapt_options where user inputs their chosen options for the cutadapt function in a txt file
3. Added a section in the log info to read out the cutadapt options file
4. Import both new modules (FASTQC_CUTADAPT and CUTADAPT)
5. Added the cutadapt module The first section deals with fastqc_cutadapt being passed without cutadapt.	fastqc_cutadapt and fastqc can't be run together if cutadapt is not also specified (they'd both received the same input and thus duplicate) so this produces an error message. fastqc_cutadapt will work if cutadapt isn't specified, but the output of cutadapt (i.e. the trimmed files) is supplied in input. The directory MUST be named *cutadapt/ otherwise it will error The second section deals with cutadapt being run. It imports the cutadapt options from the user provided txt file then runs cutadapt. It then asks if fastqc_cutadapt is also specified in modules_to_run and runs that if needed.
6. Removes the ch_salmon_multiqc section as this is not necessary now multiqc reads from the output directory. If salmon didn't run, there would be an empty channel which means multiqc couldn't be run on fastqc results alone in the original pipeline.
7. Remove the extra inputs to multiqc as they are no longer needed
8. Added a section to export the multiqc version used