### PR TITLE
Adding STAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ The pipeline is built using the [Nextflow](https://www.nextflow.io) Workflow Man
 ## Pipeline Summary
 
 1. Read QC ([FastQC](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/))
-2. Pseudo-alignment and transcript-level quantification ([Salmon](https://combine-lab.github.io/salmon/))
-3. Gene-level summarization ([tximport](https://bioconductor.org/packages/tximport/))
-4. Summarize QC Reports ([MultiQC)](https://multiqc.info/)
+2. Adapter trimming ([CUTADAPT](https://cutadapt.readthedocs.io/en/stable/index.html))
+3. Post-trimming QC ([FastQC](https://www.bioinformatics.babraham.ac.uk/projects/fastqc/))
+4. Pseudo-alignment, transcript-level quantification, and gene-level summarization ([Salmon](https://combine-lab.github.io/salmon/), [tximport](https://bioconductor.org/packages/tximport/))
+5. Alignment and gene-level quantification ([STAR](https://github.com/alexdobin/STAR), [FEATURECOUNTS](https://subread.sourceforge.net/SubreadUsersGuide.pdf))
+6. Summarize QC Reports ([MultiQC)](https://multiqc.info/)
 
 ## Install
 
@@ -57,24 +59,21 @@ version 0.0.9000
 Usage:
 The typical command for running the pipeline is as follows:
 
-    nextflow run main.nf --input /path/to/samples --transcriptome /path/to/transcriptome --salmon_index /path/to/index [OPTIONS]
+    nextflow run nf-rnaseq -profile <conda/docker/singularity> --modules salmon --input /path/to/samples --transcriptome /path/to/transcriptome --salmon_index /path/to/index [OPTIONS]
 
 Mandatory arguments:
     --input             DIRPATH             Folder containing FASTQ files, or file with
                                             4 columns: id, read_1, read_2, library_type
-    --transcriptome     FILEPATH            FASTA file containing the transcriptome (can be a gzip file)
-    --salmon_index      DIRPATH             Folder containing the index on the transcriptome. If empty
-                                            a new index will be automatically generated
-    --modules           STRING              The pipeline modules to run (default: 'fastqc,quant,multiqc').
-                                            Available modules are: fastqc, quant, multiqc
+    -profile            STRING              Container to use, one of conda, singularity, or docker.
 
 Optional arguments:
+    --modules           STRING              The pipeline modules to run. By default, all available modules will run 
+                                            ('--modules fastqc,cutadapt,fastqc_cutadapt,salmon,star,multiqc').
     --filext            STRING              Extension of input files (default: fq.gz)
     --suffix1           STRING              Suffix of first file in paired reads (default: _1)
     --suffix2           STRING              Suffix of second file in paired reads (default: _2)
     --concatenate       BOOLEAN             Whether to concatenate input files when multiple files 
-                                            per sample id are found (e.g., files from different
-                                            lanes)
+                                            per sample id are found (e.g., files from different lanes)
     --prefix            STRING              Regular expression used to identify groups of multiple
                                             files to concatenate (e.g., --prefix LANE(\d+)_)
     --species           STRING              Species of the samples (e.g., --species hsapiens). 
@@ -82,15 +81,28 @@ Optional arguments:
                                             and to download genome/transcriptome data (if required)
     --refdir            DIRPATH             Folder with reference transcriptome and (optional) genome
     --decoys           [FILEPATH]           File containing a set of decoy sequences. If the parameter is
-                                            provided without value (i.e., --decoys), a set of decoys
-                                            is attempted to be computed from the transcriptome and genome
-                                            files
+                                            provided without value (i.e. --decoys), a set of decoys
+                                            will be computed from the transcriptome and genome files.
     --genome            FILEPATH            FASTA file containing the genome (can be a gzip file)
-    --gtf               FILEPATH            Gene Transfer Format file (can be used to generate a genemap)
-    --genemap          [FILEPATH]           File containing a mapping of transcripts to genes. If the 
-                                            parameter is provided without a value (i.e., --genemap),
-                                            and a GTF file is provided in input, a mapping is attempted
-    --salmon_libtype    STRING              Library type, used for salmon quantification (default: 'A') 
+    --transcriptome     FILEPATH            FASTA file containing the transcriptome (can be a gzip file)
+    --gtf               FILEPATH            Gene Transfer Format file (can be a gzip file)
+    --genemap          [FILEPATH]           File containing a mapping of transcripts to genes used if the salmon 
+                                            module is selected.  If the parameter is provided without a
+                                            value (i.e. --genemap), and a GTF file is provided in input,
+                                            mapping is attempted.
+    --salmon_index      [DIRPATH]           Folder containing the salmon index. If the parameter is provided
+                                            without a value (i.e. --salmon_index), an index will be generated
+                                            from the transcriptome and genome files. This is a mandatory 
+                                            argument if salmon is selected.
+    --star_index        [DIRPATH]           Folder containing the STAR index. If the parameter is provided
+                                            without a value (i.e. --star_index), an index will be generated
+                                            from the genome and GTF files. This is a mandatory argument
+                                            if star is selected.                                            
+    --salmon_libtype    STRING              Library type, used for salmon quantification (default: 'A')
+    --stranded          STRING              A single integer denoting the strandedness of the reads for 
+                                            featureCounts quantification. Possible values include:
+                                            0 (unstranded), 1 (stranded) and 2 (reversely stranded).
+                                            This is a mandatory argument if star alignment is selected.
     --multiqc_config    FILEPATH            Config yaml file for MultiQC
     --outdir            DIRPATH             Output directory (default: ./results)
     --cachedir          DIRPATH             Provide a centralised cache directory for containers (default: ./work)

--- a/bin/genecounts.py
+++ b/bin/genecounts.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import pandas as pd
+import sys
+from functools import reduce
+
+args = sys.argv[1:]
+directory = ''.join(args)
+
+filenames = [f for f in os.listdir(directory) if os.path.isfile(os.path.join(directory, f)) and f.endswith('.featurecounts')]
+
+dfs= []
+all_counts = filenames
+for file in all_counts:
+    f = pd.read_table((directory + "/" + file), comment="#")
+    f1 = f.iloc[:,[0,6]]
+    fc_colname = f1.columns[1]
+    fc_colname_new = fc_colname.split(sep="/")[-1]
+    fc_colname_newer = fc_colname_new.replace("_Aligned.out.bam", "")
+    f2= f1.rename(columns = {fc_colname: fc_colname_newer})
+    dfs.append(f2)
+
+def merge_df(a, b):
+    return pd.merge(a, b, how = "outer", on = "Geneid")
+
+df_final = reduce(merge_df,dfs)
+out = "genecounts.csv"
+df_final.to_csv(out, index = False)

--- a/config/modules.config
+++ b/config/modules.config
@@ -93,7 +93,7 @@ process {
         ]
     }
 
-    thName: 'STAR_INDEX' {
+    withName: 'STAR_INDEX' {
         ext.args   = ''
         publishDir = [
             path: { "${params.outdir}/star" },

--- a/config/modules.config
+++ b/config/modules.config
@@ -13,7 +13,7 @@ process {
     withName: 'TX2GENE' {
         ext.args   = ''
         publishDir = [
-            path: {"${params.outdir}/ref/${params.species}/"},
+            path: {"${params.outdir}/ref/"},
             mode: params.publishdir_mode,
             overwrite: true,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
@@ -29,9 +29,9 @@ process {
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
-
+    
     withName: 'CUTADAPT' {
-        ext.args   = ''
+        ext.args   = '-m 15 -a AGATCGGAAGAG -q 20'
         publishDir = [
             path: {"${params.outdir}/cutadapt"},
             mode: params.publishdir_mode,
@@ -49,10 +49,10 @@ process {
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
-    
+ 
     withName: 'CREATE_DECOYS_FILE' {
         publishDir = [
-            path: { "${params.outdir}/salmon/index/${params.species}" },
+            path: { "${params.outdir}/salmon/" },
             mode: params.publishdir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename },
             overwrite: true
@@ -65,7 +65,7 @@ process {
             params.gencode ? '--gencode' : ''
         ].join(' ').trim()
         publishDir = [
-            path: { "${params.outdir}/salmon/index/${params.species}" },
+            path: { "${params.outdir}/salmon/" },
             mode: params.publishdir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             //enabled: params.save_reference
@@ -89,6 +89,50 @@ process {
             path: {"${params.outdir}/salmon/tximport"},
             mode: params.publishdir_mode,
             overwrite: true,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    thName: 'STAR_INDEX' {
+        ext.args   = ''
+        publishDir = [
+            path: { "${params.outdir}/star" },
+            mode: params.publishdir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+            //enabled: params.save_reference
+        ]
+
+    }
+
+    withName: 'STAR_QUANT' {
+        ext.args   = '--outSAMtype BAM Unsorted --twopassMode Basic --sjdbOverhang 100'
+        publishDir = [
+            path: { "${params.outdir}/star/quant" },
+            mode: params.publishdir_mode,
+            overwrite: true,
+            //saveAs: { filename -> filename.equals('versions.yml') || filename.endsWith('_meta_info.json') ? null : filename }
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: 'FEATURE_COUNTS' {
+        ext.args   = '-t exon -g gene_id --primary'
+        publishDir = [
+            path: { "${params.outdir}/featureCounts" },
+            mode: params.publishdir_mode,
+            overwrite: true,
+            //saveAs: { filename -> filename.equals('versions.yml') || filename.endsWith('_meta_info.json') ? null : filename }
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: 'GENECOUNTS' {
+        ext.args   = ''
+        publishDir = [
+            path: { "${params.outdir}/featureCounts" },
+            mode: params.publishdir_mode,
+            overwrite: true,
+            //saveAs: { filename -> filename.equals('versions.yml') || filename.endsWith('_meta_info.json') ? null : filename }
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }

--- a/config/multiqc_config.yaml
+++ b/config/multiqc_config.yaml
@@ -115,9 +115,11 @@ custom_css_files: []
 # To speed up MultiQC only use the modules that you know you have files for
 run_modules:
   - custom_content
-  - fastqc
   - cutadapt
+  - fastqc
   - salmon
+  - star
+  - featureCounts
 
 # Change the order of MultiQC module subsection outputs
 report_section_order:
@@ -145,6 +147,8 @@ module_order:
       path_filters:
         - "fastqc_cutadapt/*trimmed_fastqc.zip"
   - salmon
+  - star
+  - featureCounts
 
 # SEARCH PATTERNS
 # Overwrite module filename search patterns. See multiqc/utils/search_patterns.yaml

--- a/modules/featureCounts/main.nf
+++ b/modules/featureCounts/main.nf
@@ -1,0 +1,62 @@
+/*  A Nextflow process block
+*/
+process FEATURE_COUNTS {
+     /*********** DIRECTIVES ***********/
+    //Set to true to forward process stdout to the current top stdout
+    debug false
+    //Associate process execution with custom label
+    tag "star_index"
+    //Annotate process with identifier
+    label "process_medium"
+    //Process dependencies
+    conda "bioconda::subread=2.0.6-0"
+    //To execute the script in a Singularity or Docker container
+    container "${ workflow.containerEngine == 'singularity' ?
+        'https://depot.galaxyproject.org/singularity/subread:2.0.6--he4a0461_2' :
+        'quay.io/biocontainers/subread:2.0.6--he4a0461_2'}"
+    //Specifies where to publish output
+    publishDir path: "${params.outdir}/featureCounts", mode: "${params.publishdir_mode}", overwrite: true, followLinks: true
+    
+    /*********** INPUT ***********/
+    input:
+        tuple val(meta), path(reads1), path(reads2)
+        path bam
+        path gtf
+        val stranded
+    
+    /*********** OUTPUT ***********/
+    //Define output channels and assign identifiers
+    output:
+        tuple val(meta), path ("${meta.id}.featurecounts") , emit: featurecounts
+        path "${meta.id}.featurecounts"         , emit: counts
+        path "${meta.id}.featurecounts.summary" , emit: summary
+        path "versions.yml"                     , emit: versions
+    
+    /*********** SCRIPT ***********/
+    script:
+        def args = task.ext.args ?: ''
+        def threads = (args.indexOf('-T ') > 1) ? '' : "-T ${task.cpus}"
+
+        def paired_end = (!meta.single_end) ? "-p" : ""
+
+        def gtffilename = "${gtf.name}"
+
+
+        """
+        #!/usr/bin/env bash
+
+        featureCounts ${threads} \
+            ${args} \
+            -a ${gtffilename} \
+            -o ${meta.id}.featurecounts \
+            ${paired_end} \
+            -s ${stranded} \
+            ${bam}
+
+        cat <<-END_VERSIONS > versions.yml
+        "$task.process":
+            featureCounts: \$(echo \$(featureCounts -v 2>&1) | sed -e "s/featureCounts v//g" )
+        END_VERSIONS
+
+        """
+}

--- a/modules/genecounts/main.nf
+++ b/modules/genecounts/main.nf
@@ -9,7 +9,7 @@ process GENECOUNTS {
     //Annotate process with identifier
     label "process_medium"
     //Process dependencies
-    //conda "bioconda::bioconductor-tximeta=1.12.0"
+    conda "conda-forge::pandas=2.2.2" // N.B A different version is used here than in Singularity/Docker
     //To execute the script in a Singularity or Docker container
     container "${ workflow.containerEngine == 'singularity' ?
         'https://depot.galaxyproject.org/singularity/pandas:1.5.2' : 

--- a/modules/genecounts/main.nf
+++ b/modules/genecounts/main.nf
@@ -5,7 +5,7 @@ process GENECOUNTS {
     //Set to true to forward process stdout to the current top stdout
     debug false
     //Associate process execution with custom label
-    tag "TXIMPORT_SALMON"
+    tag "GENECOUNTS"
     //Annotate process with identifier
     label "process_medium"
     //Process dependencies

--- a/modules/genecounts/main.nf
+++ b/modules/genecounts/main.nf
@@ -1,0 +1,44 @@
+/*  A Nextflow process block
+*/
+process GENECOUNTS {
+     /*********** DIRECTIVES ***********/
+    //Set to true to forward process stdout to the current top stdout
+    debug false
+    //Associate process execution with custom label
+    tag "TXIMPORT_SALMON"
+    //Annotate process with identifier
+    label "process_medium"
+    //Process dependencies
+    //conda "bioconda::bioconductor-tximeta=1.12.0"
+    //To execute the script in a Singularity or Docker container
+    container "${ workflow.containerEngine == 'singularity' ?
+        'https://depot.galaxyproject.org/singularity/pandas:1.5.2' : 
+        'quay.io/biocontainers/pandas:1.5.2'}"
+    //Specifies where to publish output
+    publishDir path: "${params.outdir}/featureCounts" , mode: "${params.publishdir_mode}", overwrite: true, followLinks: true
+    
+    /*********** INPUT ***********/
+    input:
+        path ("featureCounts/*")
+    
+    /*********** OUTPUT ***********/
+    //Define output channels and assign identifiers
+    output:
+        path "genecounts.csv"           , emit: genecounts
+        path "versions.yml"             , emit: versions
+    
+    /*********** SCRIPT ***********/
+    script: // This script is bundled with the pipeline, in /bin/
+        
+        """
+        #!/usr/bin/env bash
+        genecounts.py featureCounts
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            python: \$(echo \$(python3 --version) | sed -e "s/Python //g") 
+            pandas: \$(python3 -c "import pandas as pd; print(pd.__version__)")
+        END_VERSIONS
+
+        """
+}

--- a/modules/genomicfeatures/tx2gene/main.nf
+++ b/modules/genomicfeatures/tx2gene/main.nf
@@ -13,7 +13,7 @@ process TX2GENE {
         'https://depot.galaxyproject.org/singularity/bioconductor-genomicfeatures:1.50.2--r42hdfd78af_0' :
         'quay.io/biocontainers/bioconductor-genomicfeatures:1.50.2--r42hdfd78af_0'}"
     //Specifies where to publish output
-    publishDir path: "${params.outdir}/ref/${params.species}/" , mode: "${params.publishdir_mode}", overwrite: true, followLinks: true
+    publishDir path: "${params.outdir}/ref/" , mode: "${params.publishdir_mode}", overwrite: true, followLinks: true
     
     /*********** INPUT ***********/
     input:

--- a/modules/salmon/decoys/main.nf
+++ b/modules/salmon/decoys/main.nf
@@ -9,7 +9,7 @@ process CREATE_DECOYS_FILE {
     //Annotate process with identifier
     label "process_low"
     //Specifies where to publish output
-    publishDir path: "${params.outdir}/index/${params.species}" , mode: "${params.publishdir_mode}", overwrite: true, followLinks: true
+    publishDir path: "${params.outdir}/index" , mode: "${params.publishdir_mode}", overwrite: true, followLinks: true
     
     /*********** INPUT ***********/
     input:
@@ -63,9 +63,9 @@ process CREATE_DECOYS_FILE {
 
             cat <<-END_VERSIONS > versions.yml
             "${task.process}":
-                gunzip: \$(gunzip --version 2>&1)
-                cut: echo \$(cut --version 2>&1) | sed 's/^.*(cut) //; s/ Copyright.*\$//'
-                grep: \$(grep --version 2>&1) 
+                gunzip: \$(gunzip --version 2>&1 | head -n 1 | sed -e 's/^.*gzip) //g' )
+                cut: \$(cut --version 2>&1 | head -n 1 | sed -e 's/^.*coreutils) //g' )
+                grep: \$(grep --version 2>&1 | head -n 1 | sed -e 's/^.*grep) //g' ) 
             END_VERSIONS
 
             """
@@ -81,8 +81,8 @@ process CREATE_DECOYS_FILE {
 
             cat <<-END_VERSIONS > versions.yml
             "${task.process}":
-                grep: \$(grep --version 2>&1)
-                cut: echo \$(cut --version 2>&1) | sed 's/^.*(cut) //; s/ Copyright.*\$//'
+                cut: \$(cut --version 2>&1 | head -n 1 | sed -e 's/^.*coreutils) //g')
+                grep: \$(grep --version 2>&1 | head -n 1 | sed -e 's/^.*grep) //g' )
             END_VERSIONS
             """
         }

--- a/modules/salmon/index/main.nf
+++ b/modules/salmon/index/main.nf
@@ -15,7 +15,7 @@ process SALMON_INDEX {
         'https://depot.galaxyproject.org/singularity/salmon:1.10.0--h7e5ed60_0' : 
         'quay.io/biocontainers/salmon:1.10.0--h7e5ed60_0'}"
     //Specifies where to publish output
-    publishDir path: "${params.outdir}/index/${params.species}", mode: "${params.publishdir_mode}", overwrite: true, followLinks: true
+    publishDir path: "${params.outdir}/salmon", mode: "${params.publishdir_mode}", overwrite: true, followLinks: true
     
     /*********** INPUT ***********/
     input:
@@ -26,7 +26,7 @@ process SALMON_INDEX {
     /*********** OUTPUT ***********/
     //Define output channels and assign identifiers
     output:
-        path "./salmon"     , emit: index
+        path "./index"     , emit: index
         path "versions.yml" , emit: versions
     
     /*********** SCRIPT ***********/
@@ -66,7 +66,7 @@ process SALMON_INDEX {
             -t ${gentrome} \
             ${idecoys} \
             ${args} \
-            -i salmon
+            -i index
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":

--- a/modules/star/index/main.nf
+++ b/modules/star/index/main.nf
@@ -1,0 +1,68 @@
+/*  A Nextflow process block
+*/
+process STAR_INDEX {
+     /*********** DIRECTIVES ***********/
+    //Set to true to forward process stdout to the current top stdout
+    debug false
+    //Associate process execution with custom label
+    tag "star_index"
+    //Annotate process with identifier
+    label "process_high"
+    //Process dependencies
+    conda "bioconda::star=2.7.11b-1"
+    //To execute the script in a Singularity or Docker container
+    container "${ workflow.containerEngine == 'singularity' ?
+        'https://depot.galaxyproject.org/singularity/star:2.7.8a--0' :
+        'quay.io/biocontainers/star:2.7.8a--0'}"
+    //Specifies where to publish output
+    publishDir path: "${params.outdir}/star", mode: "${params.publishdir_mode}", overwrite: true, followLinks: true
+    
+    /*********** INPUT ***********/
+    input:
+        path gtf
+        path genome
+    
+    /*********** OUTPUT ***********/
+    //Define output channels and assign identifiers
+    output:
+        path "index/"        , emit: index
+        path "versions.yml"       , emit: versions
+    
+    /*********** SCRIPT ***********/
+    script:
+        def args = task.ext.args ?: ''
+        def threads = (args.indexOf('--runThreadN ') > 1) ? '' : "--runThreadN ${task.cpus}"
+
+        def gtffilename = "${gtf.name}"
+        def gfilename = "${genome.name}"
+
+        // Remove the gz extension if the file is gzipped. This does not affect uncompressed file names
+        def gtfbasename = gtffilename.replace(".gz", "")
+        def gbasename = gfilename.replace(".gz", "")
+
+        """
+        #!/usr/bin/env bash
+       
+        mkdir index
+
+        gunzip ${gtffilename}
+        gunzip ${gfilename}
+
+        STAR --runMode genomeGenerate \
+            ${threads} \
+            --sjdbGTFfile ${gtfbasename} \
+            --genomeFastaFiles ${gbasename} \
+            ${args} \
+            --genomeDir index/
+
+        rm ${gtfbasename}
+        rm ${gbasename}
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            star: \$(echo \$(STAR --version))
+        END_VERSIONS
+
+        """
+
+}

--- a/modules/star/quant/main.nf
+++ b/modules/star/quant/main.nf
@@ -1,0 +1,66 @@
+/*  A Nextflow process block
+*/
+process STAR_QUANT {
+     /*********** DIRECTIVES ***********/
+    //Set to true to forward process stdout to the current top stdout
+    debug false
+    //Associate process execution with custom label
+    tag "star_index"
+    //Annotate process with identifier
+    label "process_medium"
+    //Process dependencies
+    conda "bioconda::star=2.7.11b-1"
+    //To execute the script in a Singularity or Docker container
+    container "${ workflow.containerEngine == 'singularity' ?
+        'https://depot.galaxyproject.org/singularity/star:2.7.8a--0' :
+        'quay.io/biocontainers/star:2.7.8a--0'}"
+    //Specifies where to publish output
+    publishDir path: "${params.outdir}/star/quant", mode: "${params.publishdir_mode}", overwrite: true, followLinks: true
+    
+    /*********** INPUT ***********/
+    input:
+        tuple val(meta), path(reads1), path(reads2)
+        path index
+        path gtf
+    
+    /*********** OUTPUT ***********/
+    //Define output channels and assign identifiers
+    output:
+        path "${meta.id}_Aligned.out.bam"        , emit: bam
+        path "${meta.id}_Log.final.out"          , emit: log
+        path "versions.yml"                      , emit: versions
+    
+    /*********** SCRIPT ***********/
+    script:
+        def args = task.ext.args ?: ''
+        def threads = (args.indexOf('--runThreadN ') > 1) ? '' : "--runThreadN ${task.cpus}"
+
+        def files1 = reads1.join(' ')
+        def files2 = reads2.join(' ')
+                        
+        // Remove the gz extension if the file is gzipped. This does not affect uncompressed file names
+        def gtffilename = "${gtf.name}"        
+        def gtffilename_trim = gtffilename.replace(".gz", "")
+
+        """
+        #!/usr/bin/env bash
+
+        gunzip ${gtffilename}
+
+        STAR ${threads} \
+            --genomeDir ${index} \
+            --sjdbGTFfile ${gtffilename_trim} \
+            --readFilesIn ${files1} ${files2} \
+            --outFileNamePrefix ${meta.id}_ \
+            --readFilesCommand zcat \
+            ${args}
+
+        rm Homo_sapiens.GRCh38.112.chr.gtf
+
+        cat <<-END_VERSIONS > versions.yml
+        $task.process:
+            star: \$(echo \$(STAR --version))
+        END_VERSIONS
+
+        """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -53,7 +53,7 @@ params {
     gtf             = null  // Path to General Transfer Format file
     genemap         = null  // Path to file containing a mapping of transcripts to genes (tx2gene)
     salmon_index    = null  // Path to directory
-    star_index      = ""    // Path to directory
+    star_index      = null  // Path to directory
     decoys          = null  // Path to file
     gencode         = false // Boolean
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -26,7 +26,7 @@ params {
     // General
     help            = null
     publishdir_mode = 'copy'
-    modules         = 'fastqc,cutadapt,fastqc_cutadapt,quant,multiqc'
+    modules         = 'fastqc,cutadapt,fastqc_cutadapt,salmon,star,multiqc'
     verbose         = false
 
     // Output directories
@@ -53,11 +53,13 @@ params {
     gtf             = null  // Path to General Transfer Format file
     genemap         = null  // Path to file containing a mapping of transcripts to genes (tx2gene)
     salmon_index    = null  // Path to directory
+    star_index      = ""    // Path to directory
     decoys          = null  // Path to file
     gencode         = false // Boolean
 
     // Quantification
     salmon_libtype  = 'A'
+    stranded        = null
 
     // Resources limits
     max_memory      = '30.GB'

--- a/subworkflows/check_and_prepare_input.nf
+++ b/subworkflows/check_and_prepare_input.nf
@@ -326,11 +326,11 @@ workflow CHECK_AND_PREPARE_INPUT {
                             log.info "Decoys file found"
                             ch_decoys = Channel.fromPath(params.decoys, type: 'file')
                         } else {
-                                if(params.decoys instanceof String){
-                                        fn_decoys = file(params.decoys).name
-                                } else {
-                                        fn_decoys = "decoys.txt"
-                                }
+                            if(params.decoys instanceof String){
+                                fn_decoys = file(params.decoys).name
+                            } else {
+                                fn_decoys = "decoys.txt"
+                            }
                             log.info "Decoys file not found. A decoys file will be generated."
 
                             // Create decoys file.


### PR DESCRIPTION
Adds STAR
1.  STAR index called in check and prepare input
2. STAR quant
3. FeatureCounts, which quantifies star alignments
4. genecounts which compiles the featurecounts output into a single csv

Modifies where the index files are stored (i.e. removes params.species from filepaths) to tidy output. Now indexes are stored in
results/salmon/index
results/star/index

Updated readme with new updates
